### PR TITLE
NoneType error creation

### DIFF
--- a/LearningAPI/views/student_assessment.py
+++ b/LearningAPI/views/student_assessment.py
@@ -169,10 +169,16 @@ class StudentAssessmentSerializer(serializers.ModelSerializer):
     """JSON serializer"""
     assessment = AssessmentSerializer(many=False)
     status = serializers.SerializerMethodField()
+    instructor_username = serializers.SerializerMethodField() 
 
     def get_status(self, obj):
         """Return the status of assessment"""
         return obj.status.status
+
+    def get_instructor_username(self, obj):
+        """Return the instructor's username"""
+        return obj.instructor.user.username
+
     class Meta:
         model = StudentAssessment
-        fields = ('id', 'assessment', 'status', 'url', )
+        fields = ('id', 'assessment', 'status', 'url', 'instructor_username', )


### PR DESCRIPTION
I've added some logic to add instructor_username to the serializer. This will cause a NoneType error when students try to retrieve a student assessment that has no instructor object. Student will then be able to investigate which attribute is causing the NoneType error using logging statements.  

I'll provide the students with curls to import into postman so that they can recreate the error and focus on debugging with logs. 